### PR TITLE
Update source code copy to include all files.

### DIFF
--- a/run_dpkg.sh
+++ b/run_dpkg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-cp -r /dbuilder/sources/* -t /dbuilder/build/
+cp -r /dbuilder/sources/. -t /dbuilder/build/
 cd /dbuilder/build/${DBUILDER_SUBDIR}
 
 apt-get update


### PR DESCRIPTION
Fix cp command to include dotfiles when copying from /dbuilder/sources/ to /dbuilder/build/.
