### PR TITLE
Dbuilder additional packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,32 @@ docker run --rm -v `pwd`:/dbuilder/sources seznam/dbuilder:debian_jessie
 ```
 and *.deb will appear in your source directory
 
+### Optional arguments
+  - **Additional packages** - It is possible to add additional packages to dbuilder and it will create local repository containing these files. Note the volume `/dbuilder/additional_packages` in the following example. Note, that this feature is implemented in apt-based dbuilder images only now.
+
+```bash
+# add some package
+cp mypackage_1.0.9.8.2_amd64.deb ./deps/
+# add another package, note that the deb package can be located
+# in any subdirectory
+mkdir ./deps/otherpackage_subdir/
+cp otherpackage_0.22.4_all.deb ./deps/otherpackage_subdir/
+
+# build and possibly use additional packages
+docker run --rm \
+    -v `pwd`/deps:/dbuilder/additional_packages \
+    -v `pwd`/src:/dbuilder/sources \
+    seznam/dbuilder:debian_jessie
+```
+
 ### Control environment variables
   - general
     - DBUILDER_SUBDIR - cd to subdir before building starts
     - NCPUS - concurrency
-  
+
   - apt based:
     - DBUILDER_BUILD_CMD - [default="dpkg-buildpackage -j${NCPUS}"]
+    - LOCAL_REPO_PRIORITY - sets [Pin-Priority](https://wiki.debian.org/AptPreferences) to local repository created using /dbuilder/additional_packages volume.
 
 ## For maintaners
 ## Prepare

--- a/dbuilder.dockerfile
+++ b/dbuilder.dockerfile
@@ -5,7 +5,7 @@ FROM {{ name }}:{{ tag }}
 RUN apt-get update && \
 echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/10no-recommends && \
 echo 'APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/10no-suggests && \
-apt-get install -y equivs devscripts
+apt-get install -y equivs devscripts dpkg-dev
 
 {%- block volumes %}
 VOLUME /dbuilder/bin/

--- a/run_dpkg.sh
+++ b/run_dpkg.sh
@@ -4,6 +4,25 @@ set -ex
 cp -r /dbuilder/sources/. -t /dbuilder/build/
 cd /dbuilder/build/${DBUILDER_SUBDIR}
 
+# if some deb files exist in additional_packages directory, we create a trivial
+# local repository
+preinstall_debs=`find /dbuilder/additional_packages/ -name \*.deb`
+if [ -n "${preinstall_debs}" ]; then
+    repo_path=/dbuilder/local_repository
+    mkdir ${repo_path}
+    cp ${preinstall_debs} ${repo_path}
+    dpkg-scanpackages ${repo_path} > ${repo_path}/Packages
+    echo "deb file:${repo_path} ./" > /etc/apt/sources.list.d/local_repo.list
+
+    # if pin-priority is defined, propagate it
+    if [ -n "${LOCAL_REPO_PRIORITY}" ]; then
+        echo -e "Package: *\nPin: origin \"\"\nPin-Priority: ${LOCAL_REPO_PRIORITY}" \
+            > /etc/apt/preferences.d/local_repo
+    fi
+    unset repo_path
+fi
+unset preinstall_debs
+
 apt-get update
 
 mk-build-deps -i -r -t 'apt-get -f -y --force-yes'


### PR DESCRIPTION
This patch address the neccessity to include additional packages
to the building process. The packages are passed using volume
/dbuilder/additional_packages and a local repository containing
all *.deb packages within this volume will be contained there.
It is possible to use non-default Pin-Priority value using
LOCAL_REPO_PRIORITY environment variable.
