### PR TITLE
Preinstall hooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ docker run --rm \
     seznam/dbuilder:debian_jessie
 ```
 
+  - **Preinstall hooks** - It is possible to add hooks, before dbuilder tries to satisfy build dependencies. Use volume `/dbuilder/preinstall.d` and drop executable files in. All executable files from this folder will be executed in order determined by numeric `sort`.
+
+```bash
+cp 00-my-fixer.sh 10-prepare-environment.py ./preinstall.d/
+chmod +x ./preinstall.d/*
+docker run --rm \
+    -v `pwd`/preinstall.d:/dbuilder/preinstall.d \
+    -v `pwd`/src:/dbuilder/sources \
+    seznam/dbuilder:debian_jessie
+```
+
 ### Control environment variables
   - general
     - DBUILDER_SUBDIR - cd to subdir before building starts

--- a/run_dpkg.sh
+++ b/run_dpkg.sh
@@ -27,6 +27,14 @@ unset preinstall_debs
 
 apt-get update
 
+# preinstall hooks
+if [ -d /dbuilder/preinstall.d ]; then
+    for file in `find /dbuilder/preinstall.d -executable -type f | sort -n`; do
+        ${file}
+    done
+    unset file
+fi
+
 mk-build-deps -i -r -t 'apt-get -f -y --force-yes'
 ${DBUILDER_BUILD_CMD}
 


### PR DESCRIPTION
User can mount a volume with scripts, that will be executed in alphabetical order (according their name) before installing dependencies.

TODO: Missing documentation.
