### PR TITLE
Remove apt related commands from general dockerfile.

### DIFF
--- a/apt_based.dockerfile
+++ b/apt_based.dockerfile
@@ -1,5 +1,12 @@
 {% extends "dbuilder.dockerfile" %}
 
+{%- block update_and_setup %}
+RUN apt-get update && \
+echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/10no-recommends && \
+echo 'APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/10no-suggests && \
+apt-get install -y equivs devscripts dpkg-dev
+{% endblock %}
+
 {%- block custom %}
 ENV DBUILDER_BUILD_CMD="dpkg-buildpackage -j${NCPUS}"
 

--- a/dbuilder.dockerfile
+++ b/dbuilder.dockerfile
@@ -4,10 +4,8 @@ FROM {{ name }}:{{ tag }}
 
 RUN bash -c "mkdir -p /dbuilder/{additional_packages,bin,sources,build}/"
 
-RUN apt-get update && \
-echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/10no-recommends && \
-echo 'APT::Install-Suggests "0";' > /etc/apt/apt.conf.d/10no-suggests && \
-apt-get install -y equivs devscripts dpkg-dev
+{%- block update_and_setup %}
+{% endblock %}
 
 {%- block volumes %}
 VOLUME /dbuilder/bin/


### PR DESCRIPTION
In dbuilder.dockerfile were commands, which were apt related, disallowing
users to create other (for example rpm/dnf based) dbuilder images.
This patch addresses to fix this and defined new general block which
is concretized in apt_based.dockerfile. The behaviour for apt based
images is unchanged.
