### PR TITLE
feat: Add ENV configuration for sources path

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ docker run --rm \
     - DBUILDER_BUILD_CMD - [default="dpkg-buildpackage -j${NCPUS}"]
     - LOCAL_REPO_PRIORITY - sets [Pin-Priority](https://wiki.debian.org/AptPreferences) to local repository created using /dbuilder/additional_packages volume.
     - BUILD_PACKAGES_FILE_PATH - [default="../"]
+    - BUILD_SOURCES_PATH - [default="/dbuilder/sources"]
 
 ## For maintaners
 ## Prepare

--- a/apt_based.dockerfile
+++ b/apt_based.dockerfile
@@ -11,6 +11,7 @@ rm -rf /var/lib/apt/lists/*
 {%- block custom %}
 ENV DBUILDER_BUILD_CMD="dpkg-buildpackage -j${NCPUS}"
 ENV BUILD_PACKAGES_FILE_PATH="../"
+ENV BUILD_SOURCES_PATH="/dbuilder/sources/"
 
 {%- if 'preinstall_packages' in jinja_env %}
 RUN apt-get update && \

--- a/run_dpkg.sh
+++ b/run_dpkg.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -ex
 
-cp -r /dbuilder/sources/. -t /dbuilder/build/
+if [ ${BUILD_SOURCES_PATH} != "/dbuilder/build" ]; then
+    cp -r ${BUILD_SOURCES_PATH}/. -t /dbuilder/build/
+fi
 cd /dbuilder/build/${DBUILDER_SUBDIR}
 
 # if some deb files exist in additional_packages directory, we create a trivial
@@ -47,4 +49,4 @@ if [ -d /dbuilder/postinstall.d ]; then
 fi
 
 chmod 644 ${BUILD_PACKAGES_FILE_PATH}*.deb
-cp ${BUILD_PACKAGES_FILE_PATH}*.deb /dbuilder/sources/${DBUILDER_SUBDIR}
+cp ${BUILD_PACKAGES_FILE_PATH}*.deb ${BUILD_SOURCES_PATH}/${DBUILDER_SUBDIR}


### PR DESCRIPTION
This may allow usage in CI scripts, where we can't mount predefined source volumes.